### PR TITLE
Remove redundant build flags

### DIFF
--- a/org.gnome.Calendar.json
+++ b/org.gnome.Calendar.json
@@ -25,8 +25,6 @@
         "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
     "build-options" : {
-        "cflags" : "-O2 -g",
-        "cxxflags" : "-O2 -g",
         "env" : {
             "V" : "1"
         }


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.