### PR TITLE
Update evolution-data-server and remove old build options

### DIFF
--- a/org.gnome.Calendar.json
+++ b/org.gnome.Calendar.json
@@ -105,7 +105,6 @@
                 "-DENABLE_DOT_LOCKING=OFF",
                 "-DENABLE_OAUTH2=ON",
                 "-DENABLE_GTK=ON",
-                "-DENABLE_UOA=OFF",
                 "-DENABLE_GOA=ON",
                 "-DENABLE_GOOGLE=OFF",
                 "-DENABLE_EXAMPLES=OFF",
@@ -122,8 +121,8 @@
             "sources" : [
                {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/evolution-data-server/3.36/evolution-data-server-3.36.0.tar.xz",
-                    "sha256": "d4d70e6658fb9e1f85639dcff315bbdddd3aa2de2ad069b1776af3fb9e9598ec"
+                    "url": "https://download.gnome.org/sources/evolution-data-server/3.36/evolution-data-server-3.36.3.tar.xz",
+                    "sha256": "1f5f48173d0f288219d73d4f193cb921ae631932ba84030f05751c42bb003db2"
                }
             ]
         },

--- a/org.gnome.Calendar.json
+++ b/org.gnome.Calendar.json
@@ -39,7 +39,6 @@
         {
             "name" : "gnome-online-accounts",
             "config-opts" : [
-                "--disable-telepathy",
                 "--disable-documentation",
                 "--disable-backend"
             ],


### PR DESCRIPTION
We should keep evolution-data-server up to date with the version in most distros, to prevent breakage. 3.36.2 is shipping with Fedora 32 and likely with Ubuntu 20.04 also.

Remove evolution-data-server old build option -DENABLE_UOA=OFF, which is no longer present. Also remove gnome-online-accounts old build option --disable-telepathy, which is no longer present.