### PR TITLE
Update evolution-data-server to 3.36.4

### DIFF
--- a/org.gnome.Calendar.json
+++ b/org.gnome.Calendar.json
@@ -104,7 +104,6 @@
                 "-DENABLE_DOT_LOCKING=OFF",
                 "-DENABLE_OAUTH2=ON",
                 "-DENABLE_GTK=ON",
-                "-DENABLE_UOA=OFF",
                 "-DENABLE_GOA=ON",
                 "-DENABLE_GOOGLE=OFF",
                 "-DENABLE_EXAMPLES=OFF",
@@ -121,8 +120,8 @@
             "sources" : [
                {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/evolution-data-server/3.36/evolution-data-server-3.36.3.tar.xz",
-                    "sha256": "1f5f48173d0f288219d73d4f193cb921ae631932ba84030f05751c42bb003db2"
+                    "url": "https://download.gnome.org/sources/evolution-data-server/3.36/evolution-data-server-3.36.4.tar.xz",
+                    "sha256": "39f83f1eee65c18785dfc2594720d5150e3fc37ea57e7b3b9bc2c40b4d3e4c0f"
                }
             ]
         },

--- a/org.gnome.Calendar.json
+++ b/org.gnome.Calendar.json
@@ -39,7 +39,6 @@
         {
             "name" : "gnome-online-accounts",
             "config-opts" : [
-                "--disable-telepathy",
                 "--disable-documentation",
                 "--disable-backend"
             ],


### PR DESCRIPTION
Fixes CVE-2020-14928, and removes old build options.

Please see commit message for full changelog.