### PR TITLE
Gnome 3.38 update and related components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build-dir/
+.flatpak-builder/

--- a/org.gnome.Calendar.json
+++ b/org.gnome.Calendar.json
@@ -71,8 +71,8 @@
             "sources" : [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libgweather/3.36/libgweather-3.36.0.tar.xz",
-                    "sha256": "d2ffeec01788d03d1bbf35113fc2f054c6c3600721088f827bcc31e5c603a32d"
+                    "url": "https://download.gnome.org/sources/libgweather/3.36/libgweather-3.36.1.tar.xz",
+                    "sha256": "de2709f0ee233b20116d5fa9861d406071798c4aa37830ca25f5ef2c0083e450"
                 }
             ]
         },
@@ -133,8 +133,8 @@
             "sources" : [
                {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/evolution-data-server/3.36/evolution-data-server-3.36.3.tar.xz",
-                    "sha256": "1f5f48173d0f288219d73d4f193cb921ae631932ba84030f05751c42bb003db2"
+                    "url": "https://download.gnome.org/sources/evolution-data-server/3.38/evolution-data-server-3.38.0.tar.xz",
+                    "sha256": "13689a7b55765806c4d5f3b05ef6c24b0bf9957b9ed9240c2dd09a2cdb13b0af"
                }
             ]
         },
@@ -144,8 +144,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/libdazzle/3.36/libdazzle-3.36.0.tar.xz",
-                    "sha256" : "82b31bbf550fc62970c78bf7f9d55e5fae5b8ea13b24fe2d13c8c6039409d958"
+                    "url" : "https://download.gnome.org/sources/libdazzle/3.38/libdazzle-3.38.0.tar.xz",
+                    "sha256" : "e18af28217943bcec106585298a91ec3da48aa3ad62fd0992f23f0c70cd1678f"
                 }
             ]
         },
@@ -159,10 +159,9 @@
         ],
         "sources": [
             {
-            "type": "git",
-            "url": "https://source.puri.sm/Librem5/libhandy.git",
-            "tag": "v0.0.13",
-            "commit": "7a193d7692c9c76a1a94f17c4d30b585f77d177c"
+            "type" : "archive",
+            "url" : "https://gitlab.gnome.org/GNOME/libhandy/-/archive/v0.0.13/libhandy-v0.0.13.tar.gz",
+            "sha256" : "645355a009f23f254eaec7752b9489c3c2f5832397fcec75433a7e00efbfe52f"
             }
         ],
         "cleanup": ["/bin"]
@@ -173,8 +172,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/gnome-calendar/3.36/gnome-calendar-3.36.2.tar.xz",
-                    "sha256" : "d0b05345c0555a085e6e5426eab49494aba2826c856eb06fd7fdb762ec0c4c1f"
+                    "url" : "https://download.gnome.org/sources/gnome-calendar/3.38/gnome-calendar-3.38.0.tar.xz",
+                    "sha256" : "c3684252a72bb59089d071514458a4aeba417f9551ff5d548e1a5984e47b4733"
                 }
             ]
         }

--- a/org.gnome.Calendar.json
+++ b/org.gnome.Calendar.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.gnome.Calendar",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.36",
+    "runtime-version" : "3.38",
     "branch": "stable",
     "sdk" : "org.gnome.Sdk",
     "command" : "gnome-calendar",
@@ -93,6 +93,17 @@
                     "type" : "archive",
                     "url" : "https://github.com/libical/libical/releases/download/v3.0.8/libical-3.0.8.tar.gz",
                     "sha256" : "09fecacaf75ba5a242159e3a9758a5446b5ce4d0ab684f98a7040864e1d1286f"
+                }
+            ]
+        },
+        {
+            "name" : "libcanberra-gtk3",
+            "buildsystem" : "autotools",
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz",
+                    "sha256" : "c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72"
                 }
             ]
         },

--- a/org.gnome.Calendar.json
+++ b/org.gnome.Calendar.json
@@ -141,6 +141,12 @@
         {
             "name" : "libdazzle",
             "buildsystem" : "meson",
+            "config-opts" : [
+                "-Denable_gtk_doc=false",
+                "-Denable_tests=false",
+                "-Dwith_introspection=false",
+                "-Dwith_vapi=false"
+            ],
             "sources" : [
                 {
                     "type" : "archive",


### PR DESCRIPTION
See also #23, who does almost the same. I'll elaborate what I've done differently

- Add .gitignore
- Update GNOME runtime to 3.38 
  - I've decided to include libcanberra, since that is still an evolution-data-server dependency which was included in GNOME Runtime 3.36
- Update dependencies
  - I've also applied the minor updates for libgweather and I've moved libhandy to its new hosting location
- I incorporated libdazzle upstream compiler options
  - Directly taken from #23