### PR TITLE
Remove `filesystem=home`

### DIFF
--- a/org.gnome.Calendar.json
+++ b/org.gnome.Calendar.json
@@ -20,7 +20,6 @@
         "--talk-name=org.gnome.evolution.dataserver.Subprocess.Backend.*",
         "--talk-name=org.gnome.OnlineAccounts",
         "--talk-name=org.gnome.SettingsDaemon.Color",
-        "--filesystem=home",
         "--metadata=X-DConf=migrate-path=/org/gnome/calendar/"
     ],
     "cleanup": [


### PR DESCRIPTION
I'm not entirely sure... should we remove it?

I tested Calendar for months without `filesystem=home` and it's been running just fine.

Related to https://gitlab.gnome.org/GNOME/gnome-calendar/-/issues/1024

Closes https://github.com/flathub/org.gnome.Calendar/issues/71